### PR TITLE
Fix undefined behavior related to function pointer cast

### DIFF
--- a/src/cipher_common.c
+++ b/src/cipher_common.c
@@ -116,8 +116,9 @@ sqlite3mcCloneCodecParameterTable()
 }
 
 SQLITE_PRIVATE void
-sqlite3mcFreeCodecParameterTable(CodecParameter* codecParams)
+sqlite3mcFreeCodecParameterTable(void* ptr)
 {
+  CodecParameter* codecParams = (CodecParameter*)ptr;
   sqlite3_free(codecParams[0].m_params);
   sqlite3_free(codecParams);
 }

--- a/src/sqlite3mc.c
+++ b/src/sqlite3mc.c
@@ -409,7 +409,7 @@ mcRegisterCodecExtensions(sqlite3* db, char** pzErrMsg, const sqlite3_api_routin
   if (rc == SQLITE_OK)
   {
     rc = sqlite3_create_function_v2(db, "sqlite3mc_config_table", 0, SQLITE_UTF8 | SQLITE_DETERMINISTIC,
-                                    codecParameterTable, sqlite3mcConfigTable, 0, 0, (void(*)(void*)) sqlite3mcFreeCodecParameterTable);
+                                    codecParameterTable, sqlite3mcConfigTable, 0, 0, sqlite3mcFreeCodecParameterTable);
   }
 
   rc = (codecParameterTable != NULL) ? SQLITE_OK : SQLITE_NOMEM;


### PR DESCRIPTION
Casting a function pointer to a different function pointer type is undefined behavior in C, and triggers UBSan as shown below:

![image](https://github.com/user-attachments/assets/83d54cb5-7ead-4786-ba9a-b5729165aaa5)

This PR fixes this by changing the declaration of `sqlite3mcFreeCodecParameterTable` to take a `void *` pointer and avoid the cast entirely.