### PR TITLE
Fixed incorrect documentation for pcost pragma parameter

### DIFF
--- a/docs/configuration/config_sql_pragmas.md
+++ b/docs/configuration/config_sql_pragmas.md
@@ -470,10 +470,6 @@ The `PRAGMA pcost` statement allows to modify the _parallelism_ aka _the number 
 ```sql
 PRAGMA pcost = { 1 | 2 ... };
 ```
-where the value corresponds to the hash algoritm for HMAC calculation:
-- 0 = SHA1
-- 1 = SHA256
-- 2 = SHA512
 
 ---
 


### PR DESCRIPTION
I was reading the documentation related to aegis cipher scheme. 

The pcost documentation section contains example values that are unrelated to the parameter (most probably a copy/paste issue). For that, I'm assuming the table at: https://utelle.github.io/SQLite3MultipleCiphers/docs/ciphers/cipher_aegis/ is correct.  

Direct link to the concerned section: https://utelle.github.io/SQLite3MultipleCiphers/docs/configuration/config_sql_pragmas/#pragma-pcost