### PR TITLE
Allow value-level encryption to be controlled by a compiler define

### DIFF
--- a/src/sqlite3mc.c
+++ b/src/sqlite3mc.c
@@ -370,8 +370,10 @@ int sqlite3_zipfile_init(sqlite3 *db, char **pzErrMsg, const sqlite3_api_routine
 /*
 ** VLE - Value Level Encryption
 */
+#ifndef SQLITE3MC_ENABLE_VLE
 #define SQLITE3MC_ENABLE_VLE 1
-#ifdef SQLITE3MC_ENABLE_VLE
+#endif
+#if SQLITE3MC_ENABLE_VLE
 SQLITE_API
 int sqlite3_vle_init(sqlite3* db, char** pzErrMsg, const sqlite3_api_routines* pApi);
 #include "sqlite3mc_vle.c"
@@ -811,7 +813,7 @@ sqlite3mc_builtin_extensions(sqlite3* db)
     rc = sqlite3_zipfile_init(db, &errmsg, NULL);
   }
 #endif
-#ifdef SQLITE3MC_ENABLE_VLE
+#if SQLITE3MC_ENABLE_VLE
   if (rc == SQLITE_OK)
   {
     rc = sqlite3_vle_init(db, &errmsg, NULL);


### PR DESCRIPTION
## Description

Allow value-level encryption to be controlled by a compiler define. Preserve enabled default unless SQLITE3MC_ENABLE_VLE is supplied by the build.

## Type of Change

Please select the type of change:

- [x] Refactor (no behavior change)

## Problem / Motivation

For Refactors:
Allow value-level encryption to be controlled by a compiler define.

## Checklist
- [x] I have independently verified the issue
- [x] I am not submitting unverified or speculative changes
- [x] I understand that AI-assisted changes must be reviewed by a human before submission

