### PR TITLE
modernize sqlite3mcSecureZeroMemory

### DIFF
--- a/src/memory_secure.c
+++ b/src/memory_secure.c
@@ -23,7 +23,11 @@ SQLITE_PRIVATE void sqlite3mcSecureZeroMemory(void* v, size_t n)
 #elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
   memset_explicit(v, 0, n);
 #elif defined(__APPLE__) || defined(__STDC_LIB_EXT1__)
-  /* requires __STDC_WANT_LIB_EXT1__ 1 before <string.h> */
+  /* memset_s() is only declared by <string.h> when __STDC_WANT_LIB_EXT1__ is
+     set before the first inclusion, which we can't control in an amalgamation.
+     Declare it ourselves; errno_t is int and rsize_t is size_t, so this is a
+     compatible redeclaration if the header also provided it. */
+  extern int memset_s(void*, size_t, int, size_t);
   memset_s(v, n, 0, n);
 #elif defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || \
       (defined(__FreeBSD__) && __FreeBSD__ >= 11) || \

--- a/src/memory_secure.c
+++ b/src/memory_secure.c
@@ -20,12 +20,15 @@ SQLITE_PRIVATE void sqlite3mcSecureZeroMemory(void* v, size_t n)
 {
 #ifdef _WIN32
   SecureZeroMemory(v, n);
-#elif defined(__DARWIN__) || defined(__STDC_LIB_EXT1__)
-  /* memset_s() is available since OS X 10.9, */
-  /* and may be available on other platforms. */
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+  memset_explicit(v, 0, n);
+#elif defined(__APPLE__) || defined(__STDC_LIB_EXT1__)
+  /* requires __STDC_WANT_LIB_EXT1__ 1 before <string.h> */
   memset_s(v, n, 0, n);
-#elif defined(__OpenBSD__) || (defined(__FreeBSD__) && __FreeBSD__ >= 11)
-  /* Non-standard function */
+#elif defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || \
+      (defined(__FreeBSD__) && __FreeBSD__ >= 11) || \
+      (defined(__GLIBC__) && (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 25))) || \
+      defined(__EMSCRIPTEN__) || defined(__wasi__) || defined(__ANDROID__)
   explicit_bzero(v, n);
 #else
   /* Generic implementation based on volatile pointers */

--- a/src/memory_secure.c
+++ b/src/memory_secure.c
@@ -32,7 +32,8 @@ SQLITE_PRIVATE void sqlite3mcSecureZeroMemory(void* v, size_t n)
 #elif defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__) || \
       (defined(__FreeBSD__) && __FreeBSD__ >= 11) || \
       (defined(__GLIBC__) && (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 25))) || \
-      defined(__EMSCRIPTEN__) || defined(__wasi__) || defined(__ANDROID__)
+      defined(__EMSCRIPTEN__) || defined(__wasi__) || \
+      (defined(__ANDROID__) && __ANDROID_API__ >= 28)
   explicit_bzero(v, n);
 #else
   /* Generic implementation based on volatile pointers */


### PR DESCRIPTION
modernize sqlite3mcSecureZeroMemory

## Description
- `__DARWIN__` is not a compiler-defined macro. Clang on macOS defines `__APPLE__` and `__MACH__`, not `__DARWIN__`. `__DARWIN__` is a wxWidgets convention. The previous branch was not triggered under macOS.
- Add missing C23 memset_explicit
- explicit_bzero is available in far more places: 
glibc ≥ 2.25 (2017)
musl ≥ 1.1.20 (2018) — which means Emscripten and wasi-libc both have it
NetBSD, DragonFly, Android bionic

## Type of Change

- [x] Enhancement

## Checklist

- [x] I have independently verified the issue
- [x] I am not submitting unverified or speculative changes
- [x] I understand that AI-assisted changes must be reviewed by a human before submission

