### PR TITLE
Compare SQLCipher HMAC values in constant time

### DIFF
--- a/src/cipher_sqlcipher.c
+++ b/src/cipher_sqlcipher.c
@@ -347,6 +347,23 @@ GetHmacSizeSQLCipherCipher(int algorithm)
   return hmacSize;
 }
 
+/*
+** Compare two HMAC values in constant time, that is, without revealing
+** the position of the first differing byte through the execution time.
+** Returns 0 if both values are equal, 1 otherwise.
+*/
+static int
+CompareHmacSQLCipherCipher(const unsigned char* hmac1, const unsigned char* hmac2, int len)
+{
+  volatile unsigned char diff = 0;
+  int j;
+  for (j = 0; j < len; ++j)
+  {
+    diff |= hmac1[j] ^ hmac2[j];
+  }
+  return (diff != 0);
+}
+
 static int
 EncryptPageSQLCipherCipher(void* cipher, int page, unsigned char* data, int len, int reserved)
 {
@@ -482,7 +499,7 @@ DecryptPageSQLCipherCipher(void* cipher, int page, unsigned char* data, int len,
       memcpy(pgno_raw, &page, 4);
     }
     sqlcipher_hmac(sqlCipherCipher->m_hmacAlgorithm, sqlCipherCipher->m_hmacKey, KEYLENGTH_SQLCIPHER, data + offset, n + PAGE_NONCE_LEN_SQLCIPHER - offset, pgno_raw, 4, hmac_out);
-    hmacOk = (memcmp(data + n + PAGE_NONCE_LEN_SQLCIPHER, hmac_out, hmac_size) == 0);
+    hmacOk = (CompareHmacSQLCipherCipher(data + n + PAGE_NONCE_LEN_SQLCIPHER, hmac_out, hmac_size) == 0);
   }
 
   if (hmacOk != 0)


### PR DESCRIPTION
Hi Ulrich,

here's another small finding, as mentioned in #262. The fix is tiny, so I'm sending it directly as a PR.

The authenticated cipher schemes in sqlite3mc compare their authentication tags in constant time:
- ChaCha20 with `poly1305_tagcmp()`,
- AEGIS with `aegis_verify_16/32()`,
- Ascon in `ascon_aead_decrypt()`.

The `sqlcipher` scheme is the only exception: `DecryptPageSQLCipherCipher()` in `src/cipher_sqlcipher.c` checks the page HMAC with `memcmp()`. SQLCipher itself also uses a constant-time comparison (`sqlcipher_memcmp()`).

**Why it matters:** `memcmp()` may stop at the first differing byte. The time the check takes can therefore reveal how many leading bytes of a forged HMAC are correct ([CWE-208](https://cwe.mitre.org/data/definitions/208.html)). In practice this is hard to exploit, because an attacker needs write access to the file and very precise timing of many page reads. But it's a typical finding in security reviews, and it's easy to fix.

**The change** (only `src/cipher_sqlcipher.c`, +18/−1):
- A static helper `CompareHmacSQLCipherCipher()` combines all byte differences and evaluates the result only at the end, following the same pattern as `poly1305_tagcmp()`.
- It keeps `memcmp()`'s convention (0 means equal), so the call site only changes the function name.
- Behaviour and file format stay unchanged.
- The patch also applies cleanly to the `hwaccel` branch.

<details>
<summary>How I tested it</summary>

- **macOS (Apple M4 Max, Apple clang) and Linux aarch64 (GCC 13):** the CI test scripts produce identical output before and after the change, and there are no new compiler warnings.
- **Tamper tests** with `sqlcipher` (`legacy=4` and the default setting): flipping a single byte in the ciphertext, IV or HMAC of a page is still rejected. Untouched databases open as before.

</details>

Best regards,
Markus
